### PR TITLE
Change predefined shortcuts for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,19 +66,19 @@
             {
                 "command": "extension.sidePreview",
                 "key": "ctrl+q s",
-                "mac": "cmd+q s",
+                "mac": "ctrl+q s",
                 "when": "editorTextFocus"
             },
             {
                 "command": "extension.fullPreview",
                 "key": "ctrl+q f",
-                "mac": "cmd+q f",
+                "mac": "ctrl+q f",
                 "when": "editorTextFocus"
             },
             {
                 "command": "extension.inBrowser",
                 "key": "ctrl+q w",
-                "mac": "cmd+q w",
+                "mac": "ctrl+q w",
                 "when": "editorTextFocus"
             }
         ]


### PR DESCRIPTION
On OSX / macOS, CMD+Q is a system shortcut for closing applications. If this is used for chords, one can no longer close Visual Studio Code. Using something like "CTRL-Q" is perfectly fine. Reference: https://github.com/Microsoft/vscode/issues/13522
