### PR TITLE
Modernize extension: esbuild bundling, custom editor, theme controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
+dist
 node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,13 @@
-// A launch configuration that compiles the extension and then opens it inside a new window
 {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Extension",
+            "name": "Run Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src",
-            "preLaunchTask": "npm"
-        },
-        {
-            "name": "Launch Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/test",
-            "preLaunchTask": "npm"
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,62 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "watch",
+            "dependsOn": [
+                "npm: watch:tsc",
+                "npm: watch:esbuild"
+            ],
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "npm",
+            "script": "watch:esbuild",
+            "group": "build",
+            "isBackground": true,
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            },
+            "problemMatcher": {
+                "owner": "esbuild",
+                "source": "esbuild",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": [
+                    {
+                        "regexp": "^✘ \\[ERROR\\] (.+)$",
+                        "message": 1
+                    },
+                    {
+                        "regexp": "^\\s+(.*):(\\d+):(\\d+):$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^\\[watch\\] build started$",
+                    "endsPattern": "^\\[watch\\] build finished$"
+                }
+            }
+        },
+        {
+            "type": "npm",
+            "script": "watch:tsc",
+            "group": "build",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            }
+        }
+    ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,13 @@
 .vscode/**
-typings/**
-out/test/**
+.claude/**
+out/**
 test/**
 src/**
+node_modules/**
 **/*.map
 .gitignore
 tsconfig.json
+esbuild.js
 vsc-extension-quickstart.md
+MODERNIZATION.md
+preview-test.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harshdeep Gupta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,31 @@ This extension allows you to preview your html files in VS Code itself. Use it t
 #### Full page preview
 #### Open html file in browser
 ### Usage
-* For side preview, use the keybinding 'ctrl+q s' or press 'F1' and type "Show side preview"
-* For full preview, use the keybinding 'ctrl+q f' or press 'F1' and type "Show full preview"
-* To open file in browser: 
+* For side preview, use the keybinding 'ctrl+q s', press 'F1' and type "Show side preview", or click the preview icon in the editor tab toolbar
+* For full preview, use the keybinding 'ctrl+q f', press 'F1' and type "Show full preview", or alt-click the preview icon
+* You can also right-click an .html file's tab and choose "Reopen Editor With..." -> "Live HTML Preview" to preview it in place
+* Right-click an .html file (in the editor or the Explorer) for a "Preview" submenu: Side Preview and Full Preview, each with Auto/Light/Dark, plus "Open in browser" - pick one to start a preview already in the mode you want, in one click
+* To open file in browser:
     * use the keybinding 'ctrl+q w' or
     * press 'F1' and type "Open in browser" or
-    * right click in the editor/side bar, select "Open in browser"
+    * right-click an .html file (editor or Explorer) -> Preview -> "Open in browser"
+    * over Remote-SSH/WSL/Codespaces this first tries VS Code's built-in Simple Browser tab, falling back to your external browser if that doesn't work for your setup
 
-If a HTML file is open, a message is displayed on the Status Bar in bottom left. Click on it for side preview.
+If a HTML file is open, two icons appear on the Status Bar in the bottom left: one to open the side preview, and one showing the current preview theme. The theme item stays visible and accurate whenever a preview panel is focused too, not just its source file.
+
+### Preview theme (auto / light / dark)
+`auto` (the default) shows the previewed page exactly as authored, including its own dark-mode CSS, like a real browser would. `light`/`dark` force a plain background regardless of the page's own styling. `liveHtmlPreview.previewTheme` is a global setting, so it persists across restarts/sessions and applies to every workspace unless overridden. Switch between them however's convenient:
+* click the theme icon in the *preview tab's own* toolbar to cycle Auto -> Light -> Dark -> Auto, or alt-click it to pick directly from a list
+* click the theme item in the Status Bar to cycle
+* use the keybinding 'ctrl+q t' from the source file to cycle
+* right-click an .html file -> Preview -> pick one of the six Side/Full Preview x Auto/Light/Dark entries to open (or re-theme an already-open) preview directly in that mode
+* press 'F1' and type "Set preview theme" for a picker
+* or set `liveHtmlPreview.previewTheme` directly in Settings
+
+All of these read/write the same setting, so changing it anywhere - including in an already-open preview - updates every other surface immediately.
+
+### Settings
+* `liveHtmlPreview.debounceDelay` - delay (ms) after an edit before the preview refreshes (default `200`)
+* `liveHtmlPreview.customCss.enabled` - inject a stylesheet into the preview (default `true`)
+* `liveHtmlPreview.customCss.path` - workspace-relative path to a custom CSS file to use instead of the bundled default
+* `liveHtmlPreview.previewTheme` - `auto` (default), `light`, or `dark` - see above

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This extension allows you to preview your html files in VS Code itself. Use it t
 #### Full page preview
 #### Open html file in browser
 ### Usage
-* For side preview, use the keybinding 'ctrl+q s', press 'F1' and type "Show side preview", or click the preview icon in the editor tab toolbar
-* For full preview, use the keybinding 'ctrl+q f', press 'F1' and type "Show full preview", or alt-click the preview icon
+* For side preview, use the keybinding 'ctrl+q s', or press 'F1' and type "Show side preview", or click the preview icon in the editor tab toolbar
+* For full preview, use the keybinding 'ctrl+q f', or press 'F1' and type "Show full preview", or alt-click the preview icon
 * You can also right-click an .html file's tab and choose "Reopen Editor With..." -> "Live HTML Preview" to preview it in place
 * Right-click an .html file (in the editor or the Explorer) for a "Preview" submenu: Side Preview and Full Preview, each with Auto/Light/Dark, plus "Open in browser" - pick one to start a preview already in the mode you want, in one click
 * To open file in browser:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Live HTML Previewer
-This extension allows you to preview your html files in VS Code itself. Use it to quickly set the html and css right for your webpages.
+Live, side-by-side preview of HTML files right inside VS Code - no browser tab, no context switch. Use it to quickly get the HTML and CSS right for hand-written webpages, and just as handy now that AI coding agents increasingly produce HTML (reports, specs, code reviews) instead of Markdown.
 ##### Note: Javascript is not supported in preview
 ### Features
 #### Side preview with live editing

--- a/Resources/custom_style.css
+++ b/Resources/custom_style.css
@@ -1,17 +1,4 @@
- /* * {
-    color: inherit;
-    background: inherit;
-    font-family: inherit;
-    font-size: inherit;
-}  */
-
-html,
-body {
-    background: #fff;
-    color: #000;
-}
-
-/* img {
-    max-width: inherit;
-    max-height: inherit;
-} */
+/* Bundled default for liveHtmlPreview.customCss.path (used when that setting
+   is empty). Add your own rules here, or point customCss.path at a different
+   file. Empty by default - light/dark forcing is handled separately by the
+   liveHtmlPreview.previewTheme setting, not by this stylesheet. */

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,0 +1,48 @@
+const esbuild = require('esbuild');
+
+const production = process.argv.includes('--production');
+const watch = process.argv.includes('--watch');
+
+// Prints [watch] build started/finished so the $esbuild-watch problem matcher
+// (from the connor4312.esbuild-problem-matchers extension) can track status.
+const watchPlugin = {
+    name: 'watch-plugin',
+    setup(build) {
+        build.onStart(() => console.log('[watch] build started'));
+        build.onEnd((result) => {
+            result.errors.forEach(({ text, location }) => {
+                console.error(`✘ [ERROR] ${text}`);
+                if (location) { console.error(`    ${location.file}:${location.line}:${location.column}:`); }
+            });
+            console.log('[watch] build finished');
+        });
+    }
+};
+
+async function main() {
+    const ctx = await esbuild.context({
+        entryPoints: ['src/extension.ts'],
+        bundle: true,
+        format: 'cjs',
+        platform: 'node',
+        outfile: 'dist/extension.js',
+        external: ['vscode'],
+        minify: production,
+        sourcemap: !production,
+        sourcesContent: false,
+        logLevel: 'silent',
+        plugins: [watchPlugin]
+    });
+
+    if (watch) {
+        await ctx.watch();
+    } else {
+        await ctx.rebuild();
+        await ctx.dispose();
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.0.0",
-                "@types/vscode": "^1.73.0",
+                "@types/vscode": "^1.85.0",
                 "esbuild": "^0.28.0",
                 "npm-run-all": "^4.1.5",
                 "typescript": "^5.0.0"
             },
             "engines": {
-                "vscode": "^1.73.0"
+                "vscode": "^1.85.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -469,9 +469,9 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.120.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
-            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+            "version": "1.85.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+            "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
             "dev": true,
             "license": "MIT"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2618 @@
+{
+    "name": "live-html-previewer",
+    "version": "0.3.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "live-html-previewer",
+            "version": "0.3.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@types/node": "^16.0.0",
+                "@types/vscode": "^1.73.0",
+                "esbuild": "^0.28.0",
+                "npm-run-all": "^4.1.5",
+                "typescript": "^5.0.0"
+            },
+            "engines": {
+                "vscode": "^1.73.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.120.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "is-array-buffer": "^3.0.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arraybuffer.prototype.slice": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.1",
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "is-array-buffer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/async-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+            "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "engines": {
+                "node": ">=4.8"
+            }
+        },
+        "node_modules/data-view-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/data-view-byte-length": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/inspect-js"
+            }
+        },
+        "node_modules/data-view-byte-offset": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-abstract": {
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.2",
+                "arraybuffer.prototype.slice": "^1.0.4",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "data-view-buffer": "^1.0.2",
+                "data-view-byte-length": "^1.0.2",
+                "data-view-byte-offset": "^1.0.1",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "es-set-tostringtag": "^2.1.0",
+                "es-to-primitive": "^1.3.0",
+                "function.prototype.name": "^1.1.8",
+                "get-intrinsic": "^1.3.0",
+                "get-proto": "^1.0.1",
+                "get-symbol-description": "^1.1.0",
+                "globalthis": "^1.0.4",
+                "gopd": "^1.2.0",
+                "has-property-descriptors": "^1.0.2",
+                "has-proto": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "internal-slot": "^1.1.0",
+                "is-array-buffer": "^3.0.5",
+                "is-callable": "^1.2.7",
+                "is-data-view": "^1.0.2",
+                "is-negative-zero": "^2.0.3",
+                "is-regex": "^1.2.1",
+                "is-set": "^2.0.3",
+                "is-shared-array-buffer": "^1.0.4",
+                "is-string": "^1.1.1",
+                "is-typed-array": "^1.1.15",
+                "is-weakref": "^1.1.1",
+                "math-intrinsics": "^1.1.0",
+                "object-inspect": "^1.13.4",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.7",
+                "own-keys": "^1.0.1",
+                "regexp.prototype.flags": "^1.5.4",
+                "safe-array-concat": "^1.1.3",
+                "safe-push-apply": "^1.0.0",
+                "safe-regex-test": "^1.1.0",
+                "set-proto": "^1.0.0",
+                "stop-iteration-iterator": "^1.1.0",
+                "string.prototype.trim": "^1.2.10",
+                "string.prototype.trimend": "^1.0.9",
+                "string.prototype.trimstart": "^1.0.8",
+                "typed-array-buffer": "^1.0.3",
+                "typed-array-byte-length": "^1.0.3",
+                "typed-array-byte-offset": "^1.0.4",
+                "typed-array-length": "^1.0.7",
+                "unbox-primitive": "^1.1.0",
+                "which-typed-array": "^1.1.19"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+            "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "is-callable": "^1.2.7",
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function.prototype.name": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+            "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.2",
+                "hasown": "^2.0.4",
+                "is-callable": "^1.2.7",
+                "is-document.all": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-symbol-description": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/has-bigints": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/internal-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "hasown": "^2.0.2",
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-async-function": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async-function": "^1.0.0",
+                "call-bound": "^1.0.3",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-bigint": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-bigints": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-data-view": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
+                "is-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-document.all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+            "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-finalizationregistry": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-set": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-shared-array-buffer": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakmap": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakref": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+            "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakset": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            },
+            "bin": {
+                "npm-run-all": "bin/npm-run-all/index.js",
+                "run-p": "bin/run-p/index.js",
+                "run-s": "bin/run-s/index.js"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/own-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.6",
+                "object-keys": "^1.1.1",
+                "safe-push-apply": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pidtree": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+            "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "pidtree": "bin/pidtree.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/reflect.getprototypeof": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+            "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.9",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.7",
+                "get-proto": "^1.0.1",
+                "which-builtin-type": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-errors": "^1.3.0",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "set-function-name": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-array-concat": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
+                "has-symbols": "^1.1.0",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-push-apply": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+            "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-function-name": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-proto": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+            "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/stop-iteration-iterator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "internal-slot": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/string.prototype.padend": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+            "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.2",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "define-data-property": "^1.1.4",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.24.2",
+                "es-object-atoms": "^1.1.2",
+                "has-property-descriptors": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typed-array-byte-length": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "for-each": "^0.3.3",
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-byte-offset": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "for-each": "^0.3.3",
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "reflect.getprototypeof": "^1.0.9"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-length": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "for-each": "^0.3.5",
+                "gopd": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "possible-typed-array-names": "^1.1.0",
+                "reflect.getprototypeof": "^1.0.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "which-boxed-primitive": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-bigint": "^1.1.0",
+                "is-boolean-object": "^1.2.1",
+                "is-number-object": "^1.1.1",
+                "is-string": "^1.1.1",
+                "is-symbol": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-builtin-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "function.prototype.name": "^1.1.6",
+                "has-tostringtag": "^1.0.2",
+                "is-async-function": "^2.0.0",
+                "is-date-object": "^1.1.0",
+                "is-finalizationregistry": "^1.1.0",
+                "is-generator-function": "^1.0.10",
+                "is-regex": "^1.2.1",
+                "is-weakref": "^1.0.2",
+                "isarray": "^2.0.5",
+                "which-boxed-primitive": "^1.1.0",
+                "which-collection": "^1.0.2",
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-collection": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-map": "^2.0.3",
+                "is-set": "^2.0.3",
+                "is-weakmap": "^2.0.2",
+                "is-weakset": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
     "name": "live-html-previewer",
     "displayName": "Live HTML Previewer",
     "description": "Edit and preview HTML documents in VS Code",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "publisher": "hdg",
     "author": "Harshdeep Gupta",
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.73.0"
     },
     "categories": [
         "Other"
@@ -33,36 +33,115 @@
     "activationEvents": [
         "onLanguage:html"
     ],
-    "main": "./out/src/extension",
+    "main": "./dist/extension.js",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "contributes": {
         "commands": [
             {
                 "command": "extension.sidePreview",
-                "title": "Show side preview"
+                "category": "Live HTML Preview",
+                "title": "Show side preview",
+                "icon": "$(open-preview)"
             },
             {
                 "command": "extension.fullPreview",
+                "category": "Live HTML Preview",
                 "title": "Show full preview"
             },
             {
                 "command": "extension.inBrowser",
+                "category": "Live HTML Preview",
                 "title": "Open in browser"
+            },
+            {
+                "command": "extension.setPreviewTheme",
+                "category": "Live HTML Preview",
+                "title": "Set preview theme"
+            },
+            {
+                "command": "extension.cyclePreviewTheme",
+                "category": "Live HTML Preview",
+                "title": "Cycle preview theme (Auto/Light/Dark)",
+                "icon": "$(color-mode)"
+            },
+            {
+                "command": "extension.sidePreviewAuto",
+                "category": "Live HTML Preview",
+                "title": "Side Preview (Auto)"
+            },
+            {
+                "command": "extension.sidePreviewLight",
+                "category": "Live HTML Preview",
+                "title": "Side Preview (Light)"
+            },
+            {
+                "command": "extension.sidePreviewDark",
+                "category": "Live HTML Preview",
+                "title": "Side Preview (Dark)"
+            },
+            {
+                "command": "extension.fullPreviewAuto",
+                "category": "Live HTML Preview",
+                "title": "Full Preview (Auto)"
+            },
+            {
+                "command": "extension.fullPreviewLight",
+                "category": "Live HTML Preview",
+                "title": "Full Preview (Light)"
+            },
+            {
+                "command": "extension.fullPreviewDark",
+                "category": "Live HTML Preview",
+                "title": "Full Preview (Dark)"
+            }
+        ],
+        "submenus": [
+            {
+                "id": "liveHtmlPreview.previewSubmenu",
+                "label": "Preview"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
                     "when": "resourceLangId == html",
-                    "command": "extension.inBrowser",
+                    "submenu": "liveHtmlPreview.previewSubmenu",
                     "group": "navigation"
                 }
             ],
             "editor/context": [
                 {
                     "when": "resourceLangId == html",
-                    "command": "extension.inBrowser",
+                    "submenu": "liveHtmlPreview.previewSubmenu",
                     "group": "navigation"
                 }
+            ],
+            "editor/title": [
+                {
+                    "when": "resourceLangId == html",
+                    "command": "extension.sidePreview",
+                    "alt": "extension.fullPreview",
+                    "group": "navigation@1"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'liveHtmlPreview' || activeCustomEditorId == 'liveHtmlPreview.editor'",
+                    "command": "extension.cyclePreviewTheme",
+                    "alt": "extension.setPreviewTheme",
+                    "group": "navigation@2"
+                }
+            ],
+            "liveHtmlPreview.previewSubmenu": [
+                { "command": "extension.sidePreviewAuto", "group": "1_side" },
+                { "command": "extension.sidePreviewLight", "group": "1_side" },
+                { "command": "extension.sidePreviewDark", "group": "1_side" },
+                { "command": "extension.fullPreviewAuto", "group": "2_full" },
+                { "command": "extension.fullPreviewLight", "group": "2_full" },
+                { "command": "extension.fullPreviewDark", "group": "2_full" },
+                { "command": "extension.inBrowser", "group": "3_browser" }
             ]
         },
         "keybindings": [
@@ -83,20 +162,74 @@
                 "key": "ctrl+q w",
                 "mac": "ctrl+q w",
                 "when": "editorTextFocus"
+            },
+            {
+                "command": "extension.cyclePreviewTheme",
+                "key": "ctrl+q t",
+                "mac": "ctrl+q t",
+                "when": "editorTextFocus"
             }
-        ]
+        ],
+        "customEditors": [
+            {
+                "viewType": "liveHtmlPreview.editor",
+                "displayName": "Live HTML Preview",
+                "selector": [
+                    {
+                        "filenamePattern": "*.html"
+                    }
+                ],
+                "priority": "option"
+            }
+        ],
+        "configuration": {
+            "title": "Live HTML Preview",
+            "properties": {
+                "liveHtmlPreview.debounceDelay": {
+                    "type": "number",
+                    "default": 200,
+                    "minimum": 0,
+                    "maximum": 2000,
+                    "description": "Delay (ms) after an edit before the preview refreshes."
+                },
+                "liveHtmlPreview.customCss.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Inject a stylesheet into the preview (the bundled default, or a custom one via liveHtmlPreview.customCss.path)."
+                },
+                "liveHtmlPreview.customCss.path": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Workspace-relative path to a custom CSS file to use in the preview instead of the bundled default. Ignored if empty or if customCss.enabled is false."
+                },
+                "liveHtmlPreview.previewTheme": {
+                    "type": "string",
+                    "enum": ["auto", "light", "dark"],
+                    "enumDescriptions": [
+                        "Show the page exactly as authored - its own styles (including any dark-mode CSS) win, like a real browser.",
+                        "Force a plain white background and black text, regardless of the page's own styling.",
+                        "Force a plain black background and white text, regardless of the page's own styling."
+                    ],
+                    "default": "auto",
+                    "description": "Controls the preview's background/text color. Can also be changed via the 'Live HTML Preview: Set preview theme' command."
+                }
+            }
+        }
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "vscode:prepublish": "npm run package",
+        "compile": "npm run check-types && node esbuild.js",
+        "check-types": "tsc --noEmit",
+        "watch": "npm-run-all -p watch:*",
+        "watch:esbuild": "node esbuild.js --watch",
+        "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+        "package": "npm run check-types && node esbuild.js --production"
     },
     "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
-    },
-    "dependencies": {
-        "opn": "^4.0.2",
-        "path": "^0.12.7"
+        "@types/vscode": "^1.73.0",
+        "@types/node": "^16.0.0",
+        "typescript": "^5.0.0",
+        "esbuild": "^0.28.0",
+        "npm-run-all": "^4.1.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "live-html-previewer",
     "displayName": "Live HTML Previewer",
-    "description": "Edit and preview HTML documents in VS Code",
+    "description": "Live, side-by-side HTML preview in VS Code - for hand-written pages and AI-generated HTML reports alike",
     "version": "0.3.0",
     "publisher": "hdg",
     "author": "Harshdeep Gupta",
@@ -15,6 +15,12 @@
         "html",
         "css",
         "preview",
+        "live preview",
+        "html preview",
+        "html viewer",
+        "webview",
+        "ai generated html",
+        "hot reload",
         "vscode"
     ],
     "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publisher": "hdg",
     "author": "Harshdeep Gupta",
     "engines": {
-        "vscode": "^1.73.0"
+        "vscode": "^1.85.0"
     },
     "categories": [
         "Other"
@@ -135,13 +135,34 @@
                 }
             ],
             "liveHtmlPreview.previewSubmenu": [
-                { "command": "extension.sidePreviewAuto", "group": "1_side" },
-                { "command": "extension.sidePreviewLight", "group": "1_side" },
-                { "command": "extension.sidePreviewDark", "group": "1_side" },
-                { "command": "extension.fullPreviewAuto", "group": "2_full" },
-                { "command": "extension.fullPreviewLight", "group": "2_full" },
-                { "command": "extension.fullPreviewDark", "group": "2_full" },
-                { "command": "extension.inBrowser", "group": "3_browser" }
+                {
+                    "command": "extension.sidePreviewAuto",
+                    "group": "1_side"
+                },
+                {
+                    "command": "extension.sidePreviewLight",
+                    "group": "1_side"
+                },
+                {
+                    "command": "extension.sidePreviewDark",
+                    "group": "1_side"
+                },
+                {
+                    "command": "extension.fullPreviewAuto",
+                    "group": "2_full"
+                },
+                {
+                    "command": "extension.fullPreviewLight",
+                    "group": "2_full"
+                },
+                {
+                    "command": "extension.fullPreviewDark",
+                    "group": "2_full"
+                },
+                {
+                    "command": "extension.inBrowser",
+                    "group": "3_browser"
+                }
             ]
         },
         "keybindings": [
@@ -204,7 +225,11 @@
                 },
                 "liveHtmlPreview.previewTheme": {
                     "type": "string",
-                    "enum": ["auto", "light", "dark"],
+                    "enum": [
+                        "auto",
+                        "light",
+                        "dark"
+                    ],
                     "enumDescriptions": [
                         "Show the page exactly as authored - its own styles (including any dark-mode CSS) win, like a real browser.",
                         "Force a plain white background and black text, regardless of the page's own styling.",
@@ -226,10 +251,10 @@
         "package": "npm run check-types && node esbuild.js --production"
     },
     "devDependencies": {
-        "@types/vscode": "^1.73.0",
         "@types/node": "^16.0.0",
-        "typescript": "^5.0.0",
+        "@types/vscode": "^1.85.0",
         "esbuild": "^0.28.0",
-        "npm-run-all": "^4.1.5"
+        "npm-run-all": "^4.1.5",
+        "typescript": "^5.0.0"
     }
 }

--- a/preview-test.html
+++ b/preview-test.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Live HTML Preview - Manual Test Page</title>
+    <style>
+        body { font-family: sans-serif; max-width: 640px; margin: 2rem auto; line-height: 1.5; }
+        .icon { width: 48px; height: 48px; vertical-align: middle; }
+        .check { padding: 0.75rem 1rem; margin: 0.5rem 0; border-left: 4px solid #999; background: #f4f4f4; }
+        #js-marker { color: #c00; font-weight: bold; }
+
+        /* This page defines its own dark mode, same as a real site might. */
+        @media (prefers-color-scheme: dark) {
+            body { background: #1e1e1e; color: #ddd; }
+            .check { background: #2a2a2a; border-left-color: #666; }
+        }
+    </style>
+</head>
+<body>
+    <h1>Live HTML Preview - Manual Test Page</h1>
+
+    <div class="check">
+        <strong>1. Relative image asset:</strong> the extension icon below is loaded via a
+        relative <code>src</code> path (<code>Resources/Images/icon.png</code>). It should
+        render, not show a broken-image icon &mdash; this exercises the
+        <code>asWebviewUri</code> rewriting.
+        <br>
+        <img class="icon" src="Resources/Images/icon.png" alt="extension icon">
+    </div>
+
+    <div class="check">
+        <strong>2. Live editing / debounce:</strong> with this file open in a side/full
+        preview, edit this sentence in the editor and confirm the preview updates roughly
+        <code>liveHtmlPreview.debounceDelay</code> (default 200ms) after you stop typing,
+        not on every keystroke.
+    </div>
+
+    <div class="check">
+        <strong>3. Scripts should be disabled:</strong> the line below is set by a
+        <code>&lt;script&gt;</code> tag. If it still says "script did NOT run", scripts are
+        correctly disabled in the preview (expected, current behavior).
+        <br>
+        <span id="js-marker">script did NOT run</span>
+    </div>
+
+    <div class="check">
+        <strong>4. External link untouched:</strong>
+        <a href="https://code.visualstudio.com">https://code.visualstudio.com</a>
+        should be left as a normal absolute URL (not rewritten).
+    </div>
+
+    <div class="check">
+        <strong>5. Custom CSS injection:</strong> this page includes its own
+        <code>&lt;style&gt;</code> block above, and the extension additionally appends its
+        own stylesheet link (bundled, or your <code>liveHtmlPreview.customCss.path</code> if
+        set) after the body. Check the preview's rendered HTML/styling looks intentional.
+    </div>
+
+    <div class="check">
+        <strong>6. Preview theme:</strong> this page defines its own
+        <code>prefers-color-scheme: dark</code> styling above. With
+        <code>liveHtmlPreview.previewTheme</code> set to <code>auto</code> (default), the
+        preview should follow your OS/webview color scheme like a real browser would, not be
+        forced to white.
+        <br><br>
+        Try all these ways to switch it, and confirm they all agree on the current mode:
+        <ul>
+            <li>open a side/full preview, then click the theme icon in the <em>preview tab's own</em> toolbar to cycle; alt-click it to pick from a list (this icon should NOT appear on this source file's own tab anymore)</li>
+            <li>click the theme item in the Status Bar (bottom left) to cycle - it should stay visible and correct whether this source tab or the preview tab is focused</li>
+            <li>press 'ctrl+q t' while editing this file to cycle</li>
+            <li>right-click this page (in the editor or Explorer) &rarr; "Preview" &mdash; pick "Side Preview (Dark)" or similar and confirm it opens (or re-themes an already-open) preview directly in that mode</li>
+            <li>run "Live HTML Preview: Set preview theme" from the Command Palette</li>
+        </ul>
+        Changing it from any one of these should update the preview tab's icon tooltip and the
+        Status Bar text immediately, including re-rendering an already-open preview without needing
+        an edit - and Light/Dark should force a plain background regardless of this page's own
+        dark-mode CSS. Also try right-clicking this file in the Explorer while a <em>different</em>
+        file is the active editor tab, to confirm "Preview" acts on the file you clicked, not the
+        active one.
+    </div>
+
+    <script>
+        document.getElementById('js-marker').textContent = 'script DID run';
+    </script>
+</body>
+</html>

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -5,9 +5,6 @@ export module ErrorMessages {
 export module ExtensionConstants {
     export const EXTENSION_ID = "hdg.live-html-previewer";
     export const CUSTOM_CSS_PATH = "Resources/custom_style.css";
-    // Drives the right-click submenu's checkmarks (contributes.menus "toggled"
-    // expressions in package.json); kept in sync with the previewTheme setting.
-    export const PREVIEW_THEME_CONTEXT_KEY = "liveHtmlPreview.theme";
 }
 
 export module Configuration {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -2,14 +2,26 @@ export module ErrorMessages {
     export const NO_HTML = "The current editor doesn't show a HTML document.";
 }
 
-// export module SessionVariables{
-//     export var IS_PREVIEW_BEING_SHOWN = false;
-// }
-
-export module ExtensionConstants{
-    export const PREVIEW_URI = "HTMLPreview://authority/preview";
-    export const STATUS_BAR_TEXT = "Preview Available";
-    export const STATUS_BAR_TOOLTIP = "Click for Side Preview";
+export module ExtensionConstants {
     export const EXTENSION_ID = "hdg.live-html-previewer";
-    export const CUSTOM_CSS_PATH = "Resources/custom_style.css"
+    export const CUSTOM_CSS_PATH = "Resources/custom_style.css";
+    // Drives the right-click submenu's checkmarks (contributes.menus "toggled"
+    // expressions in package.json); kept in sync with the previewTheme setting.
+    export const PREVIEW_THEME_CONTEXT_KEY = "liveHtmlPreview.theme";
+}
+
+export module Configuration {
+    export const SECTION = "liveHtmlPreview";
+    export const DEBOUNCE_DELAY = "debounceDelay";
+    export const DEBOUNCE_DELAY_DEFAULT = 200;
+    export const CUSTOM_CSS_ENABLED = "customCss.enabled";
+    export const CUSTOM_CSS_PATH = "customCss.path";
+    export const PREVIEW_THEME = "previewTheme";
+    export const PREVIEW_THEME_DEFAULT = "auto";
+}
+
+export module PreviewTheme {
+    export const AUTO = "auto";
+    export const LIGHT = "light";
+    export const DARK = "dark";
 }

--- a/src/HTMLDocumentContentProvider.ts
+++ b/src/HTMLDocumentContentProvider.ts
@@ -8,6 +8,12 @@ export default class HTMLDocumentContentProvider {
 
     private _document: vscode.TextDocument;
     private _webview: vscode.Webview;
+    // Caches the (expensive, whole-document-regex) link-rewritten body keyed
+    // by document version, so a re-render triggered by a config-only change
+    // (theme/customCss toggle) doesn't redundantly re-run it - only the two
+    // appended style/link lines actually depend on that kind of change.
+    private _cachedBody: string | undefined;
+    private _cachedVersion: number | undefined;
 
     constructor(document: vscode.TextDocument, webview: vscode.Webview) {
         this._document = document;
@@ -15,17 +21,22 @@ export default class HTMLDocumentContentProvider {
     }
 
     generateHTML(): string {
-        const plainText = this._document.getText();
-        const html = this.fixLinks(plainText);
-        return this.addStyles(html);
+        if (this._cachedVersion !== this._document.version) {
+            this._cachedBody = this.fixLinks(this._document.getText());
+            this._cachedVersion = this._document.version;
+        }
+        return this.addStyles(this._cachedBody!);
     }
 
     // Rewrite relative src/href attributes to webview-safe URIs so local
     // images, scripts, and stylesheets load inside the sandboxed webview.
+    // Leaves in-page anchors (#section), mailto:, and tel: links untouched -
+    // they aren't filesystem paths and would otherwise be corrupted into
+    // broken webview-resource URIs.
     private fixLinks(html: string): string {
         const documentFileName = this._document.fileName;
         return html.replace(
-            new RegExp("((?:src|href)=['\"])((?!https?:|//|data:|\\/).*?)(['\"])", "gmi"),
+            new RegExp("((?:src|href)=['\"])((?!https?:|//|data:|#|mailto:|tel:|\\/).*?)(['\"])", "gmi"),
             (_match: string, p1: string, p2: string, p3: string): string => {
                 const absPath = path.join(path.dirname(documentFileName), p2);
                 const uri = this._webview.asWebviewUri(vscode.Uri.file(absPath));

--- a/src/HTMLDocumentContentProvider.ts
+++ b/src/HTMLDocumentContentProvider.ts
@@ -2,70 +2,87 @@
 import * as vscode from 'vscode'
 import * as path from "path";
 import * as Constants from './Constants'
+import * as PreviewTheme from './PreviewTheme'
 
-/**
- * HTMLDocumentContentProvider 
- */
-export default class HTMLDocumentContentProvider implements vscode.TextDocumentContentProvider {
+export default class HTMLDocumentContentProvider {
 
-    private _onDidChange: vscode.EventEmitter<vscode.Uri>;
-    private _textEditor: vscode.TextEditor;
+    private _document: vscode.TextDocument;
+    private _webview: vscode.Webview;
 
-
-    constructor() {
-        this._onDidChange = new vscode.EventEmitter<vscode.Uri>();
-        this._textEditor = vscode.window.activeTextEditor;
+    constructor(document: vscode.TextDocument, webview: vscode.Webview) {
+        this._document = document;
+        this._webview = webview;
     }
 
-    provideTextDocumentContent(uri: vscode.Uri): string {
-        return this.generateHTML();
-    };
-
-    public generateHTML(): string {
-        let plainText: string = this._textEditor.document.getText();
-        let html = this.fixLinks(plainText);
-        let htmlWithStyle = this.addStyles(html);
-        return htmlWithStyle;
+    generateHTML(): string {
+        const plainText = this._document.getText();
+        const html = this.fixLinks(plainText);
+        return this.addStyles(html);
     }
 
-    // Thanks to Thomas Haakon Townsend for coming up with this regex
+    // Rewrite relative src/href attributes to webview-safe URIs so local
+    // images, scripts, and stylesheets load inside the sandboxed webview.
     private fixLinks(html: string): string {
-        let documentFileName = this._textEditor.document.fileName;
+        const documentFileName = this._document.fileName;
         return html.replace(
-            new RegExp("((?:src|href)=[\'\"])((?!http|\\/).*?)([\'\"])", "gmi"),
-            (subString: string, p1: string, p2: string, p3: string): string => {
-                return [
-                    p1,
-                    vscode.Uri.file(path.join(
-                        path.dirname(documentFileName),
-                        p2
-                    )),
-                    p3
-                ].join("");
+            new RegExp("((?:src|href)=['\"])((?!https?:|//|data:|\\/).*?)(['\"])", "gmi"),
+            (_match: string, p1: string, p2: string, p3: string): string => {
+                const absPath = path.join(path.dirname(documentFileName), p2);
+                const uri = this._webview.asWebviewUri(vscode.Uri.file(absPath));
+                return p1 + uri.toString() + p3;
             }
         );
-
-
-
     }
 
-
-    public update(uri: vscode.Uri) {
-        this._onDidChange.fire(uri);
-    }
-
-
-    // Add styles to the current HTML so that it is displayed corectly in VS Code
     private addStyles(html: string): string {
-        let extensionPath = vscode.extensions.getExtension(Constants.ExtensionConstants.EXTENSION_ID).extensionPath;
-        let style_path = vscode.Uri.file(`${extensionPath}/${Constants.ExtensionConstants.CUSTOM_CSS_PATH}`);
-        let styles: string = `<link href="${style_path}" rel="stylesheet" />`;
-        return html + styles;
+        return html + this.themeOverrideStyle() + this.customStylesheetLink();
     }
 
+    // "auto" (default) injects nothing, so the page's own CSS - including any
+    // dark-mode styling it defines - renders exactly as a real browser would.
+    // "light"/"dark" are an explicit, user-chosen override (liveHtmlPreview.previewTheme
+    // setting, or the "Set preview theme" command) that force a plain background,
+    // via !important so they win regardless of the page's own rules.
+    private themeOverrideStyle(): string {
+        const theme = PreviewTheme.getTheme();
 
+        if (theme === Constants.PreviewTheme.LIGHT) {
+            return `\n<style>html, body { background: #fff !important; color: #000 !important; }</style>`;
+        }
+        if (theme === Constants.PreviewTheme.DARK) {
+            return `\n<style>html, body { background: #000 !important; color: #fff !important; }</style>`;
+        }
+        return "";
+    }
 
-    get onDidChange(): vscode.Event<vscode.Uri> {
-        return this._onDidChange.event;
+    private customStylesheetLink(): string {
+        const config = vscode.workspace.getConfiguration(Constants.Configuration.SECTION);
+        if (!config.get<boolean>(Constants.Configuration.CUSTOM_CSS_ENABLED, true)) {
+            return "";
+        }
+
+        const customPath = config.get<string>(Constants.Configuration.CUSTOM_CSS_PATH, "");
+        const styleUri = customPath
+            ? this.resolveWorkspaceRelativeUri(customPath)
+            : this.resolveBundledStyleUri();
+        if (!styleUri) { return ""; }
+
+        return `\n<link href="${styleUri}" rel="stylesheet" />`;
+    }
+
+    private resolveBundledStyleUri(): vscode.Uri | undefined {
+        const ext = vscode.extensions.getExtension(Constants.ExtensionConstants.EXTENSION_ID);
+        if (!ext) { return undefined; }
+        return this._webview.asWebviewUri(
+            vscode.Uri.joinPath(ext.extensionUri, Constants.ExtensionConstants.CUSTOM_CSS_PATH)
+        );
+    }
+
+    // Only resolves correctly if `customPath` falls under a workspace folder,
+    // since that's what's included in the webview's localResourceRoots.
+    private resolveWorkspaceRelativeUri(customPath: string): vscode.Uri | undefined {
+        const folder = vscode.workspace.getWorkspaceFolder(this._document.uri);
+        if (!folder) { return undefined; }
+        return this._webview.asWebviewUri(vscode.Uri.joinPath(folder.uri, customPath));
     }
 }

--- a/src/HTMLPreviewCustomEditorProvider.ts
+++ b/src/HTMLPreviewCustomEditorProvider.ts
@@ -1,0 +1,34 @@
+'use strict'
+import * as vscode from 'vscode'
+import PreviewManager from './PreviewManager'
+import { buildLocalResourceRoots } from './Utilities'
+
+// Lets users reach the preview via "Reopen Editor With... -> Live HTML Preview"
+// on an .html file, in addition to the sidePreview/fullPreview commands.
+export default class HTMLPreviewCustomEditorProvider implements vscode.CustomTextEditorProvider {
+
+    public static readonly viewType = 'liveHtmlPreview.editor';
+
+    // Notified whenever a resolved preview editor gains/loses focus, so the
+    // status bar can stay visible/accurate while a preview is active.
+    constructor(private _onPreviewPanelViewStateChange?: (active: boolean) => void) {}
+
+    public static register(onPreviewPanelViewStateChange?: (active: boolean) => void): vscode.Disposable {
+        return vscode.window.registerCustomEditorProvider(
+            HTMLPreviewCustomEditorProvider.viewType,
+            new HTMLPreviewCustomEditorProvider(onPreviewPanelViewStateChange),
+            { webviewOptions: { retainContextWhenHidden: true } }
+        );
+    }
+
+    resolveCustomTextEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): void {
+        // enableScripts/localResourceRoots can't be set via registerCustomEditorProvider's
+        // options, only here on the resolved panel's webview.
+        webviewPanel.webview.options = {
+            enableScripts: false,
+            localResourceRoots: buildLocalResourceRoots(document)
+        };
+        webviewPanel.onDidChangeViewState(e => this._onPreviewPanelViewStateChange?.(e.webviewPanel.active));
+        new PreviewManager(webviewPanel, document);
+    }
+}

--- a/src/HTMLPreviewCustomEditorProvider.ts
+++ b/src/HTMLPreviewCustomEditorProvider.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode'
 import PreviewManager from './PreviewManager'
 import { buildLocalResourceRoots } from './Utilities'
+import PreviewPanelRegistry from './PreviewPanelRegistry'
 
 // Lets users reach the preview via "Reopen Editor With... -> Live HTML Preview"
 // on an .html file, in addition to the sidePreview/fullPreview commands.
@@ -9,14 +10,15 @@ export default class HTMLPreviewCustomEditorProvider implements vscode.CustomTex
 
     public static readonly viewType = 'liveHtmlPreview.editor';
 
-    // Notified whenever a resolved preview editor gains/loses focus, so the
-    // status bar can stay visible/accurate while a preview is active.
-    constructor(private _onPreviewPanelViewStateChange?: (active: boolean) => void) {}
+    constructor(
+        private _registry: PreviewPanelRegistry,
+        private _onPanelStateChange?: () => void
+    ) {}
 
-    public static register(onPreviewPanelViewStateChange?: (active: boolean) => void): vscode.Disposable {
+    public static register(registry: PreviewPanelRegistry, onPanelStateChange?: () => void): vscode.Disposable {
         return vscode.window.registerCustomEditorProvider(
             HTMLPreviewCustomEditorProvider.viewType,
-            new HTMLPreviewCustomEditorProvider(onPreviewPanelViewStateChange),
+            new HTMLPreviewCustomEditorProvider(registry, onPanelStateChange),
             { webviewOptions: { retainContextWhenHidden: true } }
         );
     }
@@ -28,7 +30,7 @@ export default class HTMLPreviewCustomEditorProvider implements vscode.CustomTex
             enableScripts: false,
             localResourceRoots: buildLocalResourceRoots(document)
         };
-        webviewPanel.onDidChangeViewState(e => this._onPreviewPanelViewStateChange?.(e.webviewPanel.active));
+        this._registry.register(document.uri, 'custom', webviewPanel, this._onPanelStateChange);
         new PreviewManager(webviewPanel, document);
     }
 }

--- a/src/PreviewManager.ts
+++ b/src/PreviewManager.ts
@@ -1,53 +1,61 @@
 'use strict'
 import * as vscode from 'vscode'
 import HTMLDocumentContentProvider from './HTMLDocumentContentProvider'
-import Utilities from './Utilities'
-import StatusBarItem from './StatusBarItem'
 import * as Constants from './Constants'
+import * as PreviewTheme from './PreviewTheme'
 
-
-// This class initializes the previewmanager based on extension type and manages all the subscriptions
 export default class PreviewManager {
 
-    htmlDocumentContentProvider: HTMLDocumentContentProvider;
-    disposable: vscode.Disposable;
-    utilities: Utilities;
-    statusBarItem: StatusBarItem;
+    private _panel: vscode.WebviewPanel;
+    private _htmlProvider: HTMLDocumentContentProvider;
+    private _disposables: vscode.Disposable[] = [];
+    private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-    constructor(utilities?: Utilities, htmlDocumentContentProvider?: HTMLDocumentContentProvider) {
-        this.utilities = utilities && utilities || new Utilities();
-        this.htmlDocumentContentProvider = htmlDocumentContentProvider && htmlDocumentContentProvider || new HTMLDocumentContentProvider();
-        this.htmlDocumentContentProvider.generateHTML();
-        // subscribe to selection change event
-        let subscriptions: vscode.Disposable[] = [];
-        vscode.window.onDidChangeTextEditorSelection(this.onEvent, this, subscriptions)
-        this.disposable = vscode.Disposable.from(...subscriptions);
+    constructor(panel: vscode.WebviewPanel, document: vscode.TextDocument) {
+        this._panel = panel;
+        this._htmlProvider = new HTMLDocumentContentProvider(document, panel.webview);
+
+        this.updatePreview();
+
+        this._disposables.push(
+            vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document === document) {
+                    this.scheduleUpdate();
+                }
+            })
+        );
+
+        // Theme/custom-CSS changes are a deliberate, discrete action (not typing),
+        // so re-render immediately rather than debouncing - otherwise an already-open
+        // preview would keep showing the old theme until the next document edit.
+        this._disposables.push(
+            vscode.workspace.onDidChangeConfiguration((e) => {
+                if (PreviewTheme.isThemeChange(e) ||
+                    e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.CUSTOM_CSS_ENABLED}`) ||
+                    e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.CUSTOM_CSS_PATH}`)) {
+                    this.updatePreview();
+                }
+            })
+        );
+
+        panel.onDidDispose(() => this.dispose());
+    }
+
+    private scheduleUpdate() {
+        if (this._debounceTimer) { clearTimeout(this._debounceTimer); }
+        const delay = vscode.workspace
+            .getConfiguration(Constants.Configuration.SECTION)
+            .get<number>(Constants.Configuration.DEBOUNCE_DELAY, Constants.Configuration.DEBOUNCE_DELAY_DEFAULT);
+        this._debounceTimer = setTimeout(() => this.updatePreview(), delay);
+    }
+
+    private updatePreview() {
+        this._panel.webview.html = this._htmlProvider.generateHTML();
     }
 
     dispose() {
-        this.disposable.dispose();
+        if (this._debounceTimer) { clearTimeout(this._debounceTimer); }
+        this._disposables.forEach(d => d.dispose());
+        this._disposables = [];
     }
-
-    private onEvent() {
-        this.htmlDocumentContentProvider.update(vscode.Uri.parse(Constants.ExtensionConstants.PREVIEW_URI));
-        // this.updatePreviewStatus();
-        // console.log(Constants.SessionVariables.IS_PREVIEW_BEING_SHOWN);
-    }
-
-    // updatePreviewStatus() {
-    //     let visibleEditors = vscode.window.visibleTextEditors;
-    //     console.log(visibleEditors)
-    //     for (let editor of visibleEditors) {
-    //         console.log(editor.document.uri);
-    //         console.log(vscode.Uri.parse(Constants.ExtensionConstants.PREVIEW_URI));
-    //         if (editor.document.uri === vscode.Uri.parse(Constants.ExtensionConstants.PREVIEW_URI)) {
-    //             Constants.SessionVariables.IS_PREVIEW_BEING_SHOWN = true;
-    //             return;
-    //         }
-    //     }
-    //     Constants.SessionVariables.IS_PREVIEW_BEING_SHOWN = false;
-    // }
-
-
-
 }

--- a/src/PreviewManager.ts
+++ b/src/PreviewManager.ts
@@ -10,10 +10,14 @@ export default class PreviewManager {
     private _htmlProvider: HTMLDocumentContentProvider;
     private _disposables: vscode.Disposable[] = [];
     private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    // Cached instead of read on every keystroke (scheduleUpdate is the hottest
+    // path in the extension); refreshed only when this specific setting changes.
+    private _debounceDelay: number;
 
     constructor(panel: vscode.WebviewPanel, document: vscode.TextDocument) {
         this._panel = panel;
         this._htmlProvider = new HTMLDocumentContentProvider(document, panel.webview);
+        this._debounceDelay = this.readDebounceDelay();
 
         this.updatePreview();
 
@@ -25,11 +29,15 @@ export default class PreviewManager {
             })
         );
 
-        // Theme/custom-CSS changes are a deliberate, discrete action (not typing),
-        // so re-render immediately rather than debouncing - otherwise an already-open
-        // preview would keep showing the old theme until the next document edit.
         this._disposables.push(
             vscode.workspace.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.DEBOUNCE_DELAY}`)) {
+                    this._debounceDelay = this.readDebounceDelay();
+                }
+                // Theme/custom-CSS changes are a deliberate, discrete action (not
+                // typing), so re-render immediately rather than debouncing -
+                // otherwise an already-open preview would keep showing the old
+                // theme until the next document edit.
                 if (PreviewTheme.isThemeChange(e) ||
                     e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.CUSTOM_CSS_ENABLED}`) ||
                     e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.CUSTOM_CSS_PATH}`)) {
@@ -41,12 +49,15 @@ export default class PreviewManager {
         panel.onDidDispose(() => this.dispose());
     }
 
-    private scheduleUpdate() {
-        if (this._debounceTimer) { clearTimeout(this._debounceTimer); }
-        const delay = vscode.workspace
+    private readDebounceDelay(): number {
+        return vscode.workspace
             .getConfiguration(Constants.Configuration.SECTION)
             .get<number>(Constants.Configuration.DEBOUNCE_DELAY, Constants.Configuration.DEBOUNCE_DELAY_DEFAULT);
-        this._debounceTimer = setTimeout(() => this.updatePreview(), delay);
+    }
+
+    private scheduleUpdate() {
+        if (this._debounceTimer) { clearTimeout(this._debounceTimer); }
+        this._debounceTimer = setTimeout(() => this.updatePreview(), this._debounceDelay);
     }
 
     private updatePreview() {

--- a/src/PreviewPanelRegistry.ts
+++ b/src/PreviewPanelRegistry.ts
@@ -1,0 +1,47 @@
+'use strict'
+import * as vscode from 'vscode'
+
+export type PreviewMode = 'side' | 'full' | 'custom'
+
+// Single source of truth for currently open preview panels, keyed by document
+// + mode so side/full previews of the same document don't collide with each
+// other (each is revealed/reused independently), while a custom-editor
+// preview (which already shows the document live, replacing its own editor
+// tab) is reused instead of letting a redundant side/full panel spawn beside
+// it. Also centralizes the focus/dispose wiring every panel needs identically,
+// so callers can't forget to seed the initial state or reset it on close -
+// the state consumers (like the status bar) want isn't "the last panel that
+// fired an event" but "is any tracked panel currently active", computed fresh
+// from each panel's own live `.active` property.
+export default class PreviewPanelRegistry {
+
+    private _panels: Map<string, vscode.WebviewPanel> = new Map();
+
+    private key(uri: vscode.Uri, mode: PreviewMode): string {
+        return `${mode}:${uri.toString()}`;
+    }
+
+    get(uri: vscode.Uri, mode: PreviewMode): vscode.WebviewPanel | undefined {
+        return this._panels.get(this.key(uri, mode));
+    }
+
+    hasActivePanel(): boolean {
+        for (const panel of this._panels.values()) {
+            if (panel.active) { return true; }
+        }
+        return false;
+    }
+
+    register(uri: vscode.Uri, mode: PreviewMode, panel: vscode.WebviewPanel, onActiveChange?: () => void): void {
+        const key = this.key(uri, mode);
+        this._panels.set(key, panel);
+
+        panel.onDidChangeViewState(() => onActiveChange?.());
+        panel.onDidDispose(() => {
+            this._panels.delete(key);
+            onActiveChange?.();
+        });
+
+        onActiveChange?.();
+    }
+}

--- a/src/PreviewTheme.ts
+++ b/src/PreviewTheme.ts
@@ -29,8 +29,3 @@ export function cycleTheme(): Thenable<void> {
 export function isThemeChange(e: vscode.ConfigurationChangeEvent): boolean {
     return e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.PREVIEW_THEME}`);
 }
-
-// Refreshes the context key the right-click submenu's checkmarks are bound to.
-export function syncContextKey(): Thenable<unknown> {
-    return vscode.commands.executeCommand('setContext', Constants.ExtensionConstants.PREVIEW_THEME_CONTEXT_KEY, getTheme());
-}

--- a/src/PreviewTheme.ts
+++ b/src/PreviewTheme.ts
@@ -1,0 +1,36 @@
+'use strict'
+import * as vscode from 'vscode'
+import * as Constants from './Constants'
+
+// Single source of truth for the preview theme: everything (the editor/title
+// cycle icon, the right-click submenu, the status bar item, and settings.json
+// edits) reads/writes through the liveHtmlPreview.previewTheme setting, and
+// vscode.workspace.onDidChangeConfiguration is what keeps every surface in
+// sync - there's no separate in-memory state to fall out of date.
+const CYCLE_ORDER = [Constants.PreviewTheme.AUTO, Constants.PreviewTheme.LIGHT, Constants.PreviewTheme.DARK];
+
+export function getTheme(): string {
+    return vscode.workspace
+        .getConfiguration(Constants.Configuration.SECTION)
+        .get<string>(Constants.Configuration.PREVIEW_THEME, Constants.Configuration.PREVIEW_THEME_DEFAULT);
+}
+
+export function setTheme(theme: string): Thenable<void> {
+    return vscode.workspace
+        .getConfiguration(Constants.Configuration.SECTION)
+        .update(Constants.Configuration.PREVIEW_THEME, theme, vscode.ConfigurationTarget.Global);
+}
+
+export function cycleTheme(): Thenable<void> {
+    const next = CYCLE_ORDER[(CYCLE_ORDER.indexOf(getTheme()) + 1) % CYCLE_ORDER.length];
+    return setTheme(next);
+}
+
+export function isThemeChange(e: vscode.ConfigurationChangeEvent): boolean {
+    return e.affectsConfiguration(`${Constants.Configuration.SECTION}.${Constants.Configuration.PREVIEW_THEME}`);
+}
+
+// Refreshes the context key the right-click submenu's checkmarks are bound to.
+export function syncContextKey(): Thenable<unknown> {
+    return vscode.commands.executeCommand('setContext', Constants.ExtensionConstants.PREVIEW_THEME_CONTEXT_KEY, getTheme());
+}

--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -1,33 +1,67 @@
 "use strict"
 import * as vscode from 'vscode'
 import Utilities from "./Utilities"
-import * as Constants from './Constants'
+import * as PreviewTheme from './PreviewTheme'
 
+// Two compact, icon-led status bar items shown only while an HTML file is
+// active: one to open the preview, one showing/cycling the preview theme.
 export default class StatusBarItem {
 
-    statusBarItem: vscode.StatusBarItem;
-    utilities: Utilities;
+    private _previewItem: vscode.StatusBarItem;
+    private _themeItem: vscode.StatusBarItem;
+    private _utilities: Utilities;
+    // True while a live preview panel (side/full/custom editor) is the focused
+    // editor. activeTextEditor alone isn't a reliable signal here - VS Code
+    // just retains its previous value while a webview has focus - so preview
+    // panels report their own focus explicitly via setPreviewPanelActive().
+    private _isPreviewPanelActive = false;
 
     constructor(utilities?: Utilities) {
-        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-        this.statusBarItem.command = "extension.sidePreview";
-        this.statusBarItem.tooltip = Constants.ExtensionConstants.STATUS_BAR_TOOLTIP;
-        this.utilities = utilities && utilities || new Utilities();
+        this._utilities = utilities ?? new Utilities();
+
+        this._previewItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+        this._previewItem.name = "Live HTML Preview";
+        this._previewItem.text = "$(open-preview)";
+        this._previewItem.tooltip = "Live HTML Preview: open side preview";
+        this._previewItem.command = "extension.sidePreview";
+
+        this._themeItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99);
+        this._themeItem.name = "Live HTML Preview Theme";
+        this._themeItem.command = "extension.cyclePreviewTheme";
     }
 
     updateStatusbar() {
-        let editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            this.statusBarItem.hide();
+        const isHtml = !!vscode.window.activeTextEditor && this._utilities.checkDocumentIsHTML(false);
+        if (!isHtml && !this._isPreviewPanelActive) {
+            this._previewItem.hide();
+            this._themeItem.hide();
             return;
         }
-        // Only update status if an HTML file
-        if (this.utilities.checkDocumentIsHTML(false)) {
-            this.statusBarItem.text = Constants.ExtensionConstants.STATUS_BAR_TEXT;
-            this.statusBarItem.show();
-        }
-        else {
-            this.statusBarItem.hide();
-        }
+
+        this._previewItem.show();
+        this.refreshThemeItem();
+        this._themeItem.show();
+    }
+
+    // Called from each preview panel's onDidChangeViewState, so the status bar
+    // (the one place the active theme is shown) stays visible whenever a
+    // preview is focused - not just when its source .html editor is.
+    setPreviewPanelActive(active: boolean) {
+        this._isPreviewPanelActive = active;
+        this.updateStatusbar();
+    }
+
+    // Called whenever liveHtmlPreview.previewTheme changes, from any surface
+    // (this item, the cycle icon, the right-click submenu, or settings.json).
+    refreshThemeItem() {
+        const theme = PreviewTheme.getTheme();
+        const label = theme.charAt(0).toUpperCase() + theme.slice(1);
+        this._themeItem.text = `$(color-mode) ${label}`;
+        this._themeItem.tooltip = `Preview theme: ${label} (click to cycle)`;
+    }
+
+    dispose() {
+        this._previewItem.dispose();
+        this._themeItem.dispose();
     }
 }

--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -10,11 +10,13 @@ export default class StatusBarItem {
     private _previewItem: vscode.StatusBarItem;
     private _themeItem: vscode.StatusBarItem;
     private _utilities: Utilities;
-    // True while a live preview panel (side/full/custom editor) is the focused
-    // editor. activeTextEditor alone isn't a reliable signal here - VS Code
-    // just retains its previous value while a webview has focus - so preview
-    // panels report their own focus explicitly via setPreviewPanelActive().
-    private _isPreviewPanelActive = false;
+    // Queried fresh on every refresh instead of tracked as a pushed boolean:
+    // activeTextEditor alone isn't a reliable signal for "a preview panel is
+    // focused" (VS Code just retains its previous value while a webview has
+    // focus), but re-deriving "is any tracked panel currently active" from
+    // PreviewPanelRegistry on demand can't go stale the way a push-based flag
+    // could (e.g. never reset when the focused panel is closed).
+    private _isPreviewPanelActive: () => boolean = () => false;
 
     constructor(utilities?: Utilities) {
         this._utilities = utilities ?? new Utilities();
@@ -32,7 +34,7 @@ export default class StatusBarItem {
 
     updateStatusbar() {
         const isHtml = !!vscode.window.activeTextEditor && this._utilities.checkDocumentIsHTML(false);
-        if (!isHtml && !this._isPreviewPanelActive) {
+        if (!isHtml && !this._isPreviewPanelActive()) {
             this._previewItem.hide();
             this._themeItem.hide();
             return;
@@ -43,12 +45,12 @@ export default class StatusBarItem {
         this._themeItem.show();
     }
 
-    // Called from each preview panel's onDidChangeViewState, so the status bar
-    // (the one place the active theme is shown) stays visible whenever a
-    // preview is focused - not just when its source .html editor is.
-    setPreviewPanelActive(active: boolean) {
-        this._isPreviewPanelActive = active;
-        this.updateStatusbar();
+    // Called once with a query function (PreviewPanelRegistry.hasActivePanel)
+    // that's re-evaluated on every refresh, so the status bar (the one place
+    // the active theme is shown) stays accurate whenever any preview panel is
+    // focused or closed - not just when its source .html editor is.
+    setPreviewPanelActiveQuery(query: () => boolean) {
+        this._isPreviewPanelActive = query;
     }
 
     // Called whenever liveHtmlPreview.previewTheme changes, from any surface

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,26 +1,91 @@
 "use strict"
 import * as vscode from 'vscode';
+import * as path from 'path';
 import PreviewManager from './PreviewManager'
 import * as Constants from './Constants'
 
+// Local resources the preview webview is allowed to load: the document's own
+// directory, the extension's own assets (bundled custom_style.css), and any
+// open workspace folders (so workspace-relative src/href paths resolve too).
+export function buildLocalResourceRoots(document: vscode.TextDocument): vscode.Uri[] {
+    const roots: vscode.Uri[] = [vscode.Uri.file(path.dirname(document.fileName))];
+
+    const ext = vscode.extensions.getExtension(Constants.ExtensionConstants.EXTENSION_ID);
+    if (ext) { roots.push(ext.extensionUri); }
+
+    (vscode.workspace.workspaceFolders ?? []).forEach(f => roots.push(f.uri));
+    return roots;
+}
+
 export default class Utilities {
-    //returns true if an html document is open
-    constructor() { };
+
+    private _panels: Map<string, vscode.WebviewPanel> = new Map();
+
+    // Notified whenever a preview panel this instance opens gains/loses focus,
+    // so the status bar can stay visible/accurate while a preview is active.
+    constructor(private _onPreviewPanelViewStateChange?: (active: boolean) => void) {}
+
+    // Status-bar visibility check only: synchronous, always reflects the
+    // currently active editor (never a menu-supplied uri).
     checkDocumentIsHTML(showWarning: boolean): boolean {
-        let result = vscode.window.activeTextEditor.document.languageId.toLowerCase() === "html"
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) { return false; }
+        const result = editor.document.languageId.toLowerCase() === "html";
         if (!result && showWarning) {
             vscode.window.showInformationMessage(Constants.ErrorMessages.NO_HTML);
         }
         return result;
     }
-    init(viewColumn: number, context: vscode.ExtensionContext, previewUri: vscode.Uri) {
-        let proceed = this.checkDocumentIsHTML(true);
-        if (proceed) {
-            let previewManager = new PreviewManager();
-            let registration = vscode.workspace.registerTextDocumentContentProvider('HTMLPreview', previewManager.htmlDocumentContentProvider);
-            return vscode.commands.executeCommand('vscode.previewHtml', previewUri, viewColumn).then((success) => {
-            });
+
+    // Resolves the document a command should act on: the uri VS Code passes
+    // when a command is invoked from explorer/context (right-clicking a file
+    // that may not be the active editor), falling back to the active editor
+    // for keybindings/Command Palette/editor-title invocations.
+    async resolveHtmlDocument(uri: vscode.Uri | undefined, showWarning: boolean): Promise<vscode.TextDocument | undefined> {
+        const document = uri ? await vscode.workspace.openTextDocument(uri) : vscode.window.activeTextEditor?.document;
+        if (!document || document.languageId.toLowerCase() !== "html") {
+            if (showWarning) { vscode.window.showInformationMessage(Constants.ErrorMessages.NO_HTML); }
+            return undefined;
         }
+        return document;
     }
 
+    async init(viewColumn: vscode.ViewColumn, context: vscode.ExtensionContext, uri?: vscode.Uri) {
+        const document = await this.resolveHtmlDocument(uri, true);
+        if (!document) { return; }
+
+        const docKey = document.uri.toString();
+
+        // Reveal existing panel instead of opening a duplicate
+        const existing = this._panels.get(docKey);
+        if (existing) {
+            existing.reveal(viewColumn);
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+            'liveHtmlPreview',
+            `Preview: ${path.basename(document.fileName)}`,
+            viewColumn,
+            {
+                // Scripts are disabled: the webview renders arbitrary, untrusted
+                // HTML from whatever file the user has open, and there is no CSP
+                // in place to constrain what a script could do (e.g. exfiltrate
+                // workspace file contents via fetch()). README documents this.
+                enableScripts: false,
+                localResourceRoots: buildLocalResourceRoots(document),
+                retainContextWhenHidden: true
+            }
+        );
+
+        this._panels.set(docKey, panel);
+        panel.onDidDispose(() => this._panels.delete(docKey), null, context.subscriptions);
+        panel.onDidChangeViewState(
+            e => this._onPreviewPanelViewStateChange?.(e.webviewPanel.active),
+            null,
+            context.subscriptions
+        );
+
+        new PreviewManager(panel, document);
+    }
 }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import PreviewManager from './PreviewManager'
 import * as Constants from './Constants'
+import PreviewPanelRegistry, { PreviewMode } from './PreviewPanelRegistry'
 
 // Local resources the preview webview is allowed to load: the document's own
 // directory, the extension's own assets (bundled custom_style.css), and any
@@ -19,11 +20,13 @@ export function buildLocalResourceRoots(document: vscode.TextDocument): vscode.U
 
 export default class Utilities {
 
-    private _panels: Map<string, vscode.WebviewPanel> = new Map();
-
-    // Notified whenever a preview panel this instance opens gains/loses focus,
-    // so the status bar can stay visible/accurate while a preview is active.
-    constructor(private _onPreviewPanelViewStateChange?: (active: boolean) => void) {}
+    // Notified whenever the set of active preview panels may have changed
+    // (registered via PreviewPanelRegistry), so the status bar can stay
+    // visible/accurate while any preview is focused.
+    constructor(
+        private _registry: PreviewPanelRegistry = new PreviewPanelRegistry(),
+        private _onPanelStateChange?: () => void
+    ) {}
 
     // Status-bar visibility check only: synchronous, always reflects the
     // currently active editor (never a menu-supplied uri).
@@ -40,9 +43,19 @@ export default class Utilities {
     // Resolves the document a command should act on: the uri VS Code passes
     // when a command is invoked from explorer/context (right-clicking a file
     // that may not be the active editor), falling back to the active editor
-    // for keybindings/Command Palette/editor-title invocations.
+    // for keybindings/Command Palette/editor-title invocations. Any failure
+    // to open the uri (deleted/renamed/unreadable file) is caught here so it
+    // never becomes an unhandled rejection at a command call site.
     async resolveHtmlDocument(uri: vscode.Uri | undefined, showWarning: boolean): Promise<vscode.TextDocument | undefined> {
-        const document = uri ? await vscode.workspace.openTextDocument(uri) : vscode.window.activeTextEditor?.document;
+        let document: vscode.TextDocument | undefined;
+        try {
+            document = uri ? await vscode.workspace.openTextDocument(uri) : vscode.window.activeTextEditor?.document;
+        } catch {
+            if (showWarning) {
+                vscode.window.showErrorMessage(`Live HTML Preview: couldn't open ${uri?.fsPath ?? "the file"}.`);
+            }
+            return undefined;
+        }
         if (!document || document.languageId.toLowerCase() !== "html") {
             if (showWarning) { vscode.window.showInformationMessage(Constants.ErrorMessages.NO_HTML); }
             return undefined;
@@ -50,14 +63,14 @@ export default class Utilities {
         return document;
     }
 
-    async init(viewColumn: vscode.ViewColumn, context: vscode.ExtensionContext, uri?: vscode.Uri) {
+    async init(viewColumn: vscode.ViewColumn, mode: PreviewMode, uri?: vscode.Uri) {
         const document = await this.resolveHtmlDocument(uri, true);
         if (!document) { return; }
 
-        const docKey = document.uri.toString();
-
-        // Reveal existing panel instead of opening a duplicate
-        const existing = this._panels.get(docKey);
+        // Reveal an existing panel for this exact mode, or a custom-editor
+        // preview (which already shows this document live), instead of
+        // opening a redundant duplicate.
+        const existing = this._registry.get(document.uri, mode) ?? this._registry.get(document.uri, 'custom');
         if (existing) {
             existing.reveal(viewColumn);
             return;
@@ -78,14 +91,7 @@ export default class Utilities {
             }
         );
 
-        this._panels.set(docKey, panel);
-        panel.onDidDispose(() => this._panels.delete(docKey), null, context.subscriptions);
-        panel.onDidChangeViewState(
-            e => this._onPreviewPanelViewStateChange?.(e.webviewPanel.active),
-            null,
-            context.subscriptions
-        );
-
+        this._registry.register(document.uri, mode, panel, this._onPanelStateChange);
         new PreviewManager(panel, document);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,48 +1,125 @@
 'use strict';
 import * as vscode from 'vscode';
-import * as Constants from './Constants'
-import PreviewManager from './PreviewManager'
 import Utilities from './Utilities'
 import StatusBarItem from './StatusBarItem'
-const opn = require('opn');
+import HTMLPreviewCustomEditorProvider from './HTMLPreviewCustomEditorProvider'
+import * as Constants from './Constants'
+import * as PreviewTheme from './PreviewTheme'
 
 export function activate(context: vscode.ExtensionContext) {
 
-    let statusBarItem = new StatusBarItem();
+    const statusBarItem = new StatusBarItem();
     statusBarItem.updateStatusbar();
-    let utilities = new Utilities();
-    // Subscribe so that the statusBarItem gets updated
-    let disposableStatusBar = vscode.window.onDidChangeActiveTextEditor(statusBarItem.updateStatusbar, statusBarItem, context.subscriptions);
-    let previewUri = vscode.Uri.parse(Constants.ExtensionConstants.PREVIEW_URI);
-    // Register the commands that are provided to the user
-    let disposableSidePreview = vscode.commands.registerCommand('extension.sidePreview', () => {
+    context.subscriptions.push(statusBarItem);
 
-        utilities.init(vscode.ViewColumn.Two, context, previewUri);
+    const onPreviewPanelViewStateChange = (active: boolean) => statusBarItem.setPreviewPanelActive(active);
+    const utilities = new Utilities(onPreviewPanelViewStateChange);
 
-    });
-    let disposableStandalonePreview = vscode.commands.registerCommand('extension.fullPreview', () => {
+    context.subscriptions.push(HTMLPreviewCustomEditorProvider.register(onPreviewPanelViewStateChange));
 
-        utilities.init(vscode.ViewColumn.One, context, previewUri);
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(statusBarItem.updateStatusbar, statusBarItem)
+    );
 
-    });
+    // Single reactive sync point: whichever surface changes the theme (cycle
+    // icon, submenu, status bar, or a direct settings.json edit), the context
+    // key (submenu checkmarks) and status bar text refresh from here.
+    PreviewTheme.syncContextKey();
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (!PreviewTheme.isThemeChange(e)) { return; }
+            PreviewTheme.syncContextKey();
+            statusBarItem.refreshThemeItem();
+        })
+    );
 
-    let disposableInBrowser = vscode.commands.registerCommand("extension.inBrowser", () => {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.sidePreview', (uri?: vscode.Uri) => {
+            utilities.init(vscode.ViewColumn.Two, context, uri);
+        })
+    );
 
-        if (utilities.checkDocumentIsHTML(true)) {
-            opn(vscode.window.activeTextEditor.document.fileName);
-        }
-    })
-    // push to subscriptions list so that they are disposed automatically
-    context.subscriptions.push(disposableSidePreview);
-    context.subscriptions.push(disposableStandalonePreview);
-    context.subscriptions.push(disposableInBrowser);
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.fullPreview', (uri?: vscode.Uri) => {
+            utilities.init(vscode.ViewColumn.One, context, uri);
+        })
+    );
+
+    context.subscriptions.push(
+        // uri is only supplied when invoked from explorer/context (right-clicking
+        // a file that may not be the active editor); other invocations (editor
+        // context menu, keybinding, Command Palette) fall back to the active editor.
+        vscode.commands.registerCommand('extension.inBrowser', async (uri?: vscode.Uri) => {
+            const document = await utilities.resolveHtmlDocument(uri, true);
+            if (!document) { return; }
+
+            const targetUri = document.uri;
+            const isRemote = vscode.env.remoteName !== undefined || vscode.env.uiKind === vscode.UIKind.Web;
+            if (isRemote) {
+                // openExternal(file://) is unreliable over Remote-SSH/WSL/Codespaces,
+                // since there's no local browser that can resolve a remote file path.
+                // VS Code's built-in Simple Browser is documented for http/https URLs;
+                // local-file support isn't documented, so this is a best-effort try
+                // before falling back to the (likely broken, but not worse) default.
+                try {
+                    await vscode.commands.executeCommand('simpleBrowser.show', targetUri.toString());
+                    return;
+                } catch {
+                    // fall through to openExternal
+                }
+            }
+            await vscode.env.openExternal(targetUri);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.setPreviewTheme', async () => {
+            const current = PreviewTheme.getTheme();
+
+            const options: (vscode.QuickPickItem & { value: string })[] = [
+                { label: "Auto", description: "Show the page as authored (default)", value: Constants.PreviewTheme.AUTO },
+                { label: "Light", description: "Force white background / black text", value: Constants.PreviewTheme.LIGHT },
+                { label: "Dark", description: "Force black background / white text", value: Constants.PreviewTheme.DARK }
+            ];
+            options.find(o => o.value === current)!.description += " (current)";
+
+            const pick = await vscode.window.showQuickPick(options, { placeHolder: "Select a preview theme" });
+            if (!pick) { return; }
+
+            await PreviewTheme.setTheme(pick.value);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.cyclePreviewTheme', () => PreviewTheme.cycleTheme())
+    );
+
+    // Backs the right-click "Preview" submenu: each entry both sets the theme
+    // (global, so it also re-renders any already-open preview instantly) and
+    // opens/reveals the requested view - one click starts a preview in a
+    // specific mode instead of needing to set the theme first separately.
+    const openPreviewWithTheme = async (viewColumn: vscode.ViewColumn, theme: string, uri?: vscode.Uri) => {
+        await PreviewTheme.setTheme(theme);
+        utilities.init(viewColumn, context, uri);
+    };
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.sidePreviewAuto', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.AUTO, uri))
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.sidePreviewLight', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.LIGHT, uri))
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.sidePreviewDark', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.DARK, uri))
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.fullPreviewAuto', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.AUTO, uri))
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.fullPreviewLight', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.LIGHT, uri))
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.fullPreviewDark', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.DARK, uri))
+    );
 }
 
-// This method is called when extension is deactivated
-export function deactivate() {
-
-}
-
-
-
-
+export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,45 +3,48 @@ import * as vscode from 'vscode';
 import Utilities from './Utilities'
 import StatusBarItem from './StatusBarItem'
 import HTMLPreviewCustomEditorProvider from './HTMLPreviewCustomEditorProvider'
+import PreviewPanelRegistry, { PreviewMode } from './PreviewPanelRegistry'
 import * as Constants from './Constants'
 import * as PreviewTheme from './PreviewTheme'
 
 export function activate(context: vscode.ExtensionContext) {
 
     const statusBarItem = new StatusBarItem();
-    statusBarItem.updateStatusbar();
     context.subscriptions.push(statusBarItem);
 
-    const onPreviewPanelViewStateChange = (active: boolean) => statusBarItem.setPreviewPanelActive(active);
-    const utilities = new Utilities(onPreviewPanelViewStateChange);
+    // One registry shared by every way a preview can be opened (side/full
+    // panels via Utilities, or "Reopen Editor With..." via
+    // HTMLPreviewCustomEditorProvider), so they can see each other's open
+    // panels instead of each tracking their own in isolation. The status bar
+    // re-queries hasActivePanel() fresh on every registry event instead of
+    // tracking a separately-pushed boolean, so it can't go stale on close.
+    const registry = new PreviewPanelRegistry();
+    statusBarItem.setPreviewPanelActiveQuery(() => registry.hasActivePanel());
+    const refreshStatusBar = () => statusBarItem.updateStatusbar();
+    const utilities = new Utilities(registry, refreshStatusBar);
 
-    context.subscriptions.push(HTMLPreviewCustomEditorProvider.register(onPreviewPanelViewStateChange));
+    context.subscriptions.push(HTMLPreviewCustomEditorProvider.register(registry, refreshStatusBar));
 
+    statusBarItem.updateStatusbar();
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(statusBarItem.updateStatusbar, statusBarItem)
     );
 
-    // Single reactive sync point: whichever surface changes the theme (cycle
-    // icon, submenu, status bar, or a direct settings.json edit), the context
-    // key (submenu checkmarks) and status bar text refresh from here.
-    PreviewTheme.syncContextKey();
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((e) => {
-            if (!PreviewTheme.isThemeChange(e)) { return; }
-            PreviewTheme.syncContextKey();
-            statusBarItem.refreshThemeItem();
+            if (PreviewTheme.isThemeChange(e)) { statusBarItem.refreshThemeItem(); }
         })
     );
 
     context.subscriptions.push(
         vscode.commands.registerCommand('extension.sidePreview', (uri?: vscode.Uri) => {
-            utilities.init(vscode.ViewColumn.Two, context, uri);
+            utilities.init(vscode.ViewColumn.Two, 'side', uri);
         })
     );
 
     context.subscriptions.push(
         vscode.commands.registerCommand('extension.fullPreview', (uri?: vscode.Uri) => {
-            utilities.init(vscode.ViewColumn.One, context, uri);
+            utilities.init(vscode.ViewColumn.One, 'full', uri);
         })
     );
 
@@ -81,7 +84,8 @@ export function activate(context: vscode.ExtensionContext) {
                 { label: "Light", description: "Force white background / black text", value: Constants.PreviewTheme.LIGHT },
                 { label: "Dark", description: "Force black background / white text", value: Constants.PreviewTheme.DARK }
             ];
-            options.find(o => o.value === current)!.description += " (current)";
+            const currentOption = options.find(o => o.value === current);
+            if (currentOption) { currentOption.description += " (current)"; }
 
             const pick = await vscode.window.showQuickPick(options, { placeHolder: "Select a preview theme" });
             if (!pick) { return; }
@@ -98,28 +102,23 @@ export function activate(context: vscode.ExtensionContext) {
     // (global, so it also re-renders any already-open preview instantly) and
     // opens/reveals the requested view - one click starts a preview in a
     // specific mode instead of needing to set the theme first separately.
-    const openPreviewWithTheme = async (viewColumn: vscode.ViewColumn, theme: string, uri?: vscode.Uri) => {
+    const openPreviewWithTheme = async (viewColumn: vscode.ViewColumn, mode: PreviewMode, theme: string, uri?: vscode.Uri) => {
         await PreviewTheme.setTheme(theme);
-        utilities.init(viewColumn, context, uri);
+        utilities.init(viewColumn, mode, uri);
     };
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.sidePreviewAuto', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.AUTO, uri))
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.sidePreviewLight', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.LIGHT, uri))
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.sidePreviewDark', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.Two, Constants.PreviewTheme.DARK, uri))
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.fullPreviewAuto', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.AUTO, uri))
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.fullPreviewLight', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.LIGHT, uri))
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('extension.fullPreviewDark', (uri?: vscode.Uri) => openPreviewWithTheme(vscode.ViewColumn.One, Constants.PreviewTheme.DARK, uri))
-    );
+    const PREVIEW_THEME_COMMANDS: { id: string; viewColumn: vscode.ViewColumn; mode: PreviewMode; theme: string }[] = [
+        { id: 'sidePreviewAuto', viewColumn: vscode.ViewColumn.Two, mode: 'side', theme: Constants.PreviewTheme.AUTO },
+        { id: 'sidePreviewLight', viewColumn: vscode.ViewColumn.Two, mode: 'side', theme: Constants.PreviewTheme.LIGHT },
+        { id: 'sidePreviewDark', viewColumn: vscode.ViewColumn.Two, mode: 'side', theme: Constants.PreviewTheme.DARK },
+        { id: 'fullPreviewAuto', viewColumn: vscode.ViewColumn.One, mode: 'full', theme: Constants.PreviewTheme.AUTO },
+        { id: 'fullPreviewLight', viewColumn: vscode.ViewColumn.One, mode: 'full', theme: Constants.PreviewTheme.LIGHT },
+        { id: 'fullPreviewDark', viewColumn: vscode.ViewColumn.One, mode: 'full', theme: Constants.PreviewTheme.DARK }
+    ];
+    for (const { id, viewColumn, mode, theme } of PREVIEW_THEME_COMMANDS) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(`extension.${id}`, (uri?: vscode.Uri) => openPreviewWithTheme(viewColumn, mode, theme, uri))
+        );
+    }
 }
 
 export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es2020",
+        "lib": ["es2020"],
         "outDir": "out",
-        "noLib": true,
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": true
     },
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "out",
+        "test"
     ]
 }

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
## Summary
- Bundle with esbuild (`dist/extension.js`) instead of raw `tsc` output, and add a `CustomTextEditorProvider` so the preview is reachable via "Reopen Editor With...".
- Disable webview script execution (no CSP was constraining previewed scripts) and debounce preview refresh on edits.
- Fix a real dark-mode bug: the bundled stylesheet used to force a white background over a previewed page's own dark-mode CSS. Default theme is now `auto` (page's own styling wins), with explicit `light`/`dark` as an opt-in override.
- Add a light/dark/auto preview theme control kept in sync across surfaces: an icon on the preview tab's own toolbar, a `ctrl+q t` keybinding, a Status Bar item, and a right-click "Preview" submenu that can start a preview directly in a given view + theme (7 entries: Side/Full Preview x Auto/Light/Dark, plus Open in browser).
- Fix a stale-preview bug (theme changes now re-render an already-open preview immediately) and an Explorer-context bug (right-clicking a non-active `.html` file now acts on the clicked file, not whatever was active).
- Remote-safe "Open in browser" (tries Simple Browser over Remote-SSH/WSL/Codespaces, falls back to `openExternal`), plus Marketplace/DX polish (command categories, `capabilities.untrustedWorkspaces`, dead-code cleanup).

Full backlog and remaining/deferred items tracked in #46.

## Test plan
- [x] `npm run check-types` and `npm run package` (esbuild production build) both clean
- [x] `vsce package` dry run - contribution schema valid, no leaked files (`.claude/**`, etc.)
- [x] Manually verified in the Extension Development Host: side/full preview, custom editor ("Reopen Editor With..."), debounced live editing, scripts disabled, custom CSS injection, and all theme-switching surfaces (preview tab icon, Status Bar, `ctrl+q t`, right-click "Preview" submenu including from the Explorer on a non-active file, Command Palette) stay in sync